### PR TITLE
Observable.fromEmitter is gone on RxJava 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+Version 1.1.2 *(2017-05-12)*
+----------------------------
+Updated RxJava to version 1.3.0 and replaced deprecated fromEmitter() to create()
+
 Version 1.1.1 *(2017-01-19)*
 ----------------------------
 Updated RxJava to version 1.2.5 and replaced deprecated AsyncEmitter with Emitter

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Be sure to unregistering your receiver, this is typically done in the `Activity.
 # Installation
 
 ```groovy
-compile 'com.cantrowitz:rxbroadcast:1.0.1'
+compile 'com.cantrowitz:rxbroadcast:1.1.2'
 ```
 
 License

--- a/rxbroadcast/build.gradle
+++ b/rxbroadcast/build.gradle
@@ -28,5 +28,5 @@ dependencies {
     testCompile 'org.robolectric:robolectric:3.0'
     testCompile 'junit:junit:4.12'
     compile 'com.android.support:appcompat-v7:23.0.0'
-    compile 'io.reactivex:rxjava:1.2.5'
+    compile 'io.reactivex:rxjava:1.3.0'
 }

--- a/rxbroadcast/src/main/java/com/cantrowitz/rxbroadcast/RxBroadcast.java
+++ b/rxbroadcast/src/main/java/com/cantrowitz/rxbroadcast/RxBroadcast.java
@@ -143,7 +143,7 @@ public class RxBroadcast {
     private static Observable<Intent> createBroadcastObservable(
             final BroadcastRegistrarStrategy broadcastRegistrarStrategy,
             final OrderedBroadcastAbortStrategy orderedBroadcastAbortStrategy) {
-        return Observable.fromEmitter(new Action1<Emitter<Intent>>() {
+        return Observable.create(new Action1<Emitter<Intent>>() {
             @Override
             public void call(final Emitter<Intent> intentEmitter) {
 


### PR DESCRIPTION
Replaced it with Observable.create and updated RxJava dependency to 1.3.0.

It was causing runtime crashes.